### PR TITLE
Fix bare except usages

### DIFF
--- a/add_sql_rekt.py
+++ b/add_sql_rekt.py
@@ -8,11 +8,14 @@ from time import gmtime, strftime
 from exceptions import BaseException
 from traceback import format_exc
 import sqlite3
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 ''' CHECK, STORE EACH LIQUIDATION '''
 def addRekt():
-   print ' In Add Rekt SQLlite() '
+   print(' In Add Rekt SQLlite() ')
    sqlite_file = 'rekt.sqlite'    # name of the sqlite database file
    table_name = 'rekkage'  # name of the table to be created
    new_field = 'rekt_key' # name of the column
@@ -21,20 +24,22 @@ def addRekt():
    # Connecting to the database file
    conn = sqlite3.connect("rekt.sqlite")
    c = conn.cursor()
-   print ' Connection() open in  Add Rekt SQLlite() '
+   print(' Connection() open in  Add Rekt SQLlite() ')
    rekt_count = 0
    try:
       c.execute('SELECT 1 FROM {tn}'.format(tn=table_name))
       rekt_count = c.fetchone()
-   except:
+   except sqlite3.OperationalError:
       pass
+   except Exception:
+      logger.error(format_exc())
 
    if rekt_count == 0:
-      print "Creating new Rekkage table ... "
+      print("Creating new Rekkage table ... ")
       # Creating a new SQLite table with 1 column
       c.execute('CREATE TABLE {tn} ({nf} {ft} PRIMARY KEY, rekt_symbol TEXT, rekt_qty INTEGER, rekt_price REAL,rekt_side TEXT, rekt_position TEXT, rekt_ts TEXT)'.format(tn=table_name, nf=new_field, ft=field_type))
    else:
-      print " Table %s exists already" % table_name
+      print(" Table %s exists already" % table_name)
 
    # Committing changes and closing the connection to the database file
    conn.commit()
@@ -42,7 +47,7 @@ def addRekt():
 
 ''' CHECK, STORE EACH LIQUIDATION '''
 def addPID():
-   print ' In Add PID SQLlite() '
+   print(' In Add PID SQLlite() ')
    sqlite_file = 'rekt.sqlite'    # name of the sqlite database file
    table_name = 'rekt_PID'  # name of the table to be created
    new_field = 'rekt_PID' # name of the column
@@ -51,20 +56,22 @@ def addPID():
    # Connecting to the database file
    conn = sqlite3.connect("rekt.sqlite")
    c = conn.cursor()
-   print ' Connection() open in  Add PID SQLlite() '
+   print(' Connection() open in  Add PID SQLlite() ')
    rekt_count = 0
    try:
       c.execute('SELECT 1 FROM {tn}'.format(tn=table_name))
       rekt_count = c.fetchone()
-   except:
+   except sqlite3.OperationalError:
       pass
+   except Exception:
+      logger.error(format_exc())
 
    if rekt_count == 0:
-      print "Creating new PID table ... "
+      print("Creating new PID table ... ")
       # Creating a new SQLite table with 1 column
       c.execute('CREATE TABLE {tn} ({nf} {ft} PRIMARY_KEY)'.format(tn=table_name, nf=new_field, ft=field_type))
    else:
-      print " Table %s exists already" % table_name
+      print(" Table %s exists already" % table_name)
 
    # Committing changes and closing the connection to the database file
    conn.commit()

--- a/rektrunner.py
+++ b/rektrunner.py
@@ -26,8 +26,10 @@ def addPID():
    try:
       c.execute('SELECT 1 FROM {tn}'.format(tn=table_name))
       rekt_count = c.fetchone()
-   except:
+   except sqlite3.OperationalError:
       pass
+   except Exception:
+      logger.error(format_exc())
 
    if rekt_count == 0:
       print("Creating new PID table ... ")
@@ -55,8 +57,10 @@ def addRekt():
    try:
       c.execute('SELECT 1 FROM {tn}'.format(tn=table_name))
       rekt_count = c.fetchone()
-   except:
+   except sqlite3.OperationalError:
       pass
+   except Exception:
+      logger.error(format_exc())
 
    if rekt_count == 0:
       print("Creating new Rekkage table ... ")


### PR DESCRIPTION
## Summary
- replace bare `except:` clauses with explicit exception handling
- report unexpected exceptions to logger
- modernize prints in `add_sql_rekt.py`

## Testing
- `python -m py_compile rektrunner.py add_sql_rekt.py`

------
https://chatgpt.com/codex/tasks/task_e_6840fee611ac832881f1141f05d66ff6