### PR TITLE
Fix resource cleanup and unused import

### DIFF
--- a/add_sql_rekt.py
+++ b/add_sql_rekt.py
@@ -5,7 +5,6 @@ import requests
 import datetime
 import tweepy
 from time import gmtime, strftime
-from exceptions import BaseException
 from traceback import format_exc
 import sqlite3
 import logging
@@ -43,7 +42,7 @@ def addRekt():
 
    # Committing changes and closing the connection to the database file
    conn.commit()
-   conn.close
+   conn.close()
 
 ''' CHECK, STORE EACH LIQUIDATION '''
 def addPID():
@@ -75,7 +74,7 @@ def addPID():
 
    # Committing changes and closing the connection to the database file
    conn.commit()
-   conn.close
+   conn.close()
 
 if __name__ == "__main__":
    addRekt()

--- a/rektrunner.py
+++ b/rektrunner.py
@@ -40,7 +40,7 @@ def addPID():
 
    # Committing changes and closing the connection to the database file
    conn.commit()
-   conn.close
+   conn.close()
 
 ''' CHECK, STORE EACH LIQUIDATION '''
 def addRekt():
@@ -71,7 +71,7 @@ def addRekt():
 
    # Committing changes and closing the connection to the database file
    conn.commit()
-   conn.close
+   conn.close()
 
 
 ''' Setup logging with file, console output '''
@@ -138,7 +138,7 @@ def gotRek(rekt_key, symbol, qty, price, position, side):
       except BaseException as ex:
         logger.error(format_exc())
 
-   conn.close
+   conn.close()
    return rc
 
 ''' Get rekt details '''


### PR DESCRIPTION
## Summary
- drop unused `BaseException` import from `add_sql_rekt.py`
- close database connections with parentheses

## Testing
- `python3 -m py_compile add_sql_rekt.py rektrunner.py`

------
https://chatgpt.com/codex/tasks/task_e_68410146c130832891d356ffb8bf1750