### PR TITLE
Use environment variables for Twitter credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,15 @@ Libs are:
 - requests
 - tweepy
 
-Update the Twitter keys and token values to enable posting to twitter, otherwise comment out the call to send Twitter update.
+Set the following environment variables with your Twitter credentials to enable
+posting to Twitter:
+
+- `TWITTER_APP_KEY`
+- `TWITTER_APP_SECRET`
+- `TWITTER_ACCESS_TOKEN`
+- `TWITTER_ACCESS_TOKEN_SECRET`
+
+If these are not provided, comment out the call that sends Twitter updates.
 
 All liquidations will be stored in sqllite local DB (see rekt.sqlite). Log file named rektrunner.log will capture calls to bitmex.com
 Some code is included to ensure only one instance of the bot runs. Its not completed and doesn't make any difference to runtime.

--- a/rektrunner.py
+++ b/rektrunner.py
@@ -181,10 +181,11 @@ def WriteRekage(msgs):
      return
 
    # Consumer keys and access tokens
-   app_key             = 'ADD TWITTER APP KEY'
-   app_secret          = 'ADD TWITTER APP SECRET'
-   access_token        = 'ADD TWITTER ACCESS TOKEN'
-   access_token_secret = 'ADD TWITTER ACCESS TOKEN SECRET'
+   # Read credentials from environment variables
+   app_key             = os.getenv('TWITTER_APP_KEY')
+   app_secret          = os.getenv('TWITTER_APP_SECRET')
+   access_token        = os.getenv('TWITTER_ACCESS_TOKEN')
+   access_token_secret = os.getenv('TWITTER_ACCESS_TOKEN_SECRET')
 
    auth = tweepy.OAuthHandler(app_key,app_secret)
    auth.set_access_token(access_token,access_token_secret)


### PR DESCRIPTION
## Summary
- fetch Twitter credentials from environment variables
- document new environment variables required for posting to Twitter

## Testing
- `python -m py_compile rektrunner.py add_sql_rekt.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_684103189fcc832891f72e74b82996a8