### PR TITLE
Improve rektrunner reliability and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@
 
 Runs under Python 3.XX
 
-Install required libs by using 'pip' tool
+Install required libs by using `pip` tool and the provided `requirements.txt`
+file:
+
+```
+pip install -r requirements.txt
+```
 
 Libs are:
 
@@ -19,10 +24,29 @@ posting to Twitter:
 - `TWITTER_ACCESS_TOKEN`
 - `TWITTER_ACCESS_TOKEN_SECRET`
 
+Without these variables the bot will run but will not attempt to publish updates
+to Twitter.
+
 If these are not provided, comment out the call that sends Twitter updates.
 
 All liquidations will be stored in sqllite local DB (see rekt.sqlite). 
 
 Log file named rektrunner.log will capture calls to bitmex.com
+
+### Running Tests
+
+Install the requirements and execute `pytest`:
+
+```
+pytest -q
+```
+
+### Database Schema
+
+The SQLite database `rekt.sqlite` contains two tables:
+
+* `rekkage` - stores liquidation events (`rekt_key`, `rekt_symbol`,
+  `rekt_qty`, `rekt_price`, `rekt_position`, `rekt_side`, `rekt_ts`).
+* `rekt_PID` - stores process IDs to avoid duplicate bot instances.
 
 Run the bot by executing command: "python rektrunner.py"

--- a/add_sql_rekt.py
+++ b/add_sql_rekt.py
@@ -6,75 +6,19 @@ import datetime
 import tweepy
 from time import gmtime, strftime
 from traceback import format_exc
-import sqlite3
 import logging
+from database import init_rekkage_db, init_pid_db
 
 logger = logging.getLogger(__name__)
 
 
-''' CHECK, STORE EACH LIQUIDATION '''
 def addRekt():
-   print(' In Add Rekt SQLlite() ')
-   sqlite_file = 'rekt.sqlite'    # name of the sqlite database file
-   table_name = 'rekkage'  # name of the table to be created
-   new_field = 'rekt_key' # name of the column
-   field_type = 'TEXT'  # column data type
+    """Initialize the rekkage table."""
+    init_rekkage_db()
 
-   # Connecting to the database file
-   conn = sqlite3.connect("rekt.sqlite")
-   c = conn.cursor()
-   print(' Connection() open in  Add Rekt SQLlite() ')
-   rekt_count = 0
-   try:
-      c.execute('SELECT 1 FROM {tn}'.format(tn=table_name))
-      rekt_count = c.fetchone()
-   except sqlite3.OperationalError:
-      pass
-   except Exception:
-      logger.error(format_exc())
-
-   if rekt_count == 0:
-      print("Creating new Rekkage table ... ")
-      # Creating a new SQLite table with 1 column
-      c.execute('CREATE TABLE {tn} ({nf} {ft} PRIMARY KEY, rekt_symbol TEXT, rekt_qty INTEGER, rekt_price REAL,rekt_side TEXT, rekt_position TEXT, rekt_ts TEXT)'.format(tn=table_name, nf=new_field, ft=field_type))
-   else:
-      print(" Table %s exists already" % table_name)
-
-   # Committing changes and closing the connection to the database file
-   conn.commit()
-   conn.close()
-
-''' CHECK, STORE EACH LIQUIDATION '''
 def addPID():
-   print(' In Add PID SQLlite() ')
-   sqlite_file = 'rekt.sqlite'    # name of the sqlite database file
-   table_name = 'rekt_PID'  # name of the table to be created
-   new_field = 'rekt_PID' # name of the column
-   field_type = 'TEXT'  # column data type
-
-   # Connecting to the database file
-   conn = sqlite3.connect("rekt.sqlite")
-   c = conn.cursor()
-   print(' Connection() open in  Add PID SQLlite() ')
-   rekt_count = 0
-   try:
-      c.execute('SELECT 1 FROM {tn}'.format(tn=table_name))
-      rekt_count = c.fetchone()
-   except sqlite3.OperationalError:
-      pass
-   except Exception:
-      logger.error(format_exc())
-
-   if rekt_count == 0:
-      print("Creating new PID table ... ")
-      # Creating a new SQLite table with 1 column
-      c.execute('CREATE TABLE {tn} ({nf} {ft} PRIMARY_KEY)'.format(tn=table_name, nf=new_field, ft=field_type))
-   else:
-      print(" Table %s exists already" % table_name)
-
-   # Committing changes and closing the connection to the database file
-   conn.commit()
-   conn.close()
+    """Initialize the PID table."""
+    init_pid_db()
 
 if __name__ == "__main__":
    addRekt()

--- a/database.py
+++ b/database.py
@@ -1,0 +1,34 @@
+import logging
+import sqlite3
+from contextlib import closing
+
+logger = logging.getLogger(__name__)
+
+REKT_TABLE = "rekkage"
+PID_TABLE = "rekt_PID"
+
+
+def init_rekkage_db(db_path="rekt.sqlite"):
+    """Create the rekkage table if it does not exist."""
+    with sqlite3.connect(db_path) as conn:
+        c = conn.cursor()
+        c.execute(f"CREATE TABLE IF NOT EXISTS {REKT_TABLE} ("
+                  "rekt_key TEXT PRIMARY KEY,"
+                  " rekt_symbol TEXT,"
+                  " rekt_qty INTEGER,"
+                  " rekt_price REAL,"
+                  " rekt_position TEXT,"
+                  " rekt_side TEXT,"
+                  " rekt_ts TEXT"
+                  ")")
+        conn.commit()
+
+
+def init_pid_db(db_path="rekt.sqlite"):
+    """Create the rekt_PID table if it does not exist."""
+    with sqlite3.connect(db_path) as conn:
+        c = conn.cursor()
+        c.execute(f"CREATE TABLE IF NOT EXISTS {PID_TABLE} ("
+                  "rekt_PID TEXT PRIMARY KEY"
+                  ")")
+        conn.commit()

--- a/rektrunner.py
+++ b/rektrunner.py
@@ -9,75 +9,18 @@ from traceback import format_exc
 import sqlite3
 import subprocess
 import logging
+from config import base_url
+from database import init_rekkage_db, init_pid_db
 
-''' CHECK, STORE EACH Process ID '''
-def addPID():
-   print(' In Add PID SQLlite() ')
-   sqlite_file = 'rekt.sqlite'    # name of the sqlite database file
-   table_name = 'rekt_PID'  # name of the table to be created
-   new_field = 'rekt_PID' # name of the column
-   field_type = 'TEXT'  # column data type
-
-   # Connecting to the database file
-   conn = sqlite3.connect("rekt.sqlite")
-   c = conn.cursor()
-   print(' Connection() open in  Add PID SQLlite() ')
-   rekt_count = 0
-   try:
-      c.execute('SELECT 1 FROM {tn}'.format(tn=table_name))
-      rekt_count = c.fetchone()
-   except sqlite3.OperationalError:
-      pass
-   except Exception:
-      logger.error(format_exc())
-
-   if rekt_count == 0:
-      print("Creating new PID table ... ")
-      # Creating a new SQLite table with 1 column
-      c.execute('CREATE TABLE {tn} ({nf} {ft} PRIMARY_KEY)'.format(tn=table_name, nf=new_field, ft=field_type))
-   else:
-      print(" Table %s exists already" % table_name)
-
-   # Committing changes and closing the connection to the database file
-   conn.commit()
-   conn.close()
-
-''' CHECK, STORE EACH LIQUIDATION '''
-def addRekt():
-   print(' In Add Rekt SQLlite() ')
-   sqlite_file = 'rekt.sqlite'    # name of the sqlite database file
-   table_name = 'rekkage'  # name of the table to be created
-   new_field = 'rekt_key' # name of the column
-   field_type = 'TEXT'  # column data type
-
-   # Connecting to the database file
-   conn = sqlite3.connect("rekt.sqlite")
-   c = conn.cursor()
-   rekt_count = 0
-   try:
-      c.execute('SELECT 1 FROM {tn}'.format(tn=table_name))
-      rekt_count = c.fetchone()
-   except sqlite3.OperationalError:
-      pass
-   except Exception:
-      logger.error(format_exc())
-
-   if rekt_count == 0:
-      print("Creating new Rekkage table ... ")
-      # Creating a new SQLite table with 1 column
-      c.execute('CREATE TABLE {tn} ({nf} {ft} PRIMARY KEY, rekt_symbol TEXT, rekt_qty INTEGER, rekt_price REAL, rekt_position TEXT, rekt_side TEXT, rekt_ts TEXT)'.format(tn=table_name, nf=new_field, ft=field_type))
-   else:
-      print(" Table %s exists already" % table_name)
-
-   # Committing changes and closing the connection to the database file
-   conn.commit()
-   conn.close()
+# module level logger used by functions
+logger = logging.getLogger('RektBitmex')
 
 
-''' Setup logging with file, console output '''
+"""Setup logging with file and console output."""
 def SetupLogging():
-   # create logger with 'RektBitmex'
-   logger = logging.getLogger('RektBitmex')
+   """Return configured logger."""
+   global logger
+   # configure logger with file and console handlers
    logger.setLevel(logging.INFO)
 
    # create file handler which logs messages
@@ -96,56 +39,86 @@ def SetupLogging():
    logger.addHandler(ch)
    return logger
 
-''' Run the process only once at a time '''
+"""Exit if another instance of this script is already running."""
 def RunOnce():
+    """Check for another running instance and exit if found."""
     script_name = os.path.basename(__file__)
     l = subprocess.getstatusoutput("ps aux | grep -e '%s' | grep -v grep | awk '{print $2}'| awk '{print $2}'" % script_name)
     if l[1]:
         logger.info("process '%s' is already running, exiting now" % script_name)
         sys.exit(0);
 
-''' Check, Store each Liquidation '''
-def gotRek(rekt_key, symbol, qty, price, position, side):
-   rc = False
-   msg = []
-   table_name = 'rekkage'
-   conn = sqlite3.connect("rekt.sqlite")
-   c = conn.cursor()
-   c.execute("SELECT * FROM {tn} WHERE {idf}='{rekt_key}'".format(tn=table_name,idf='rekt_key', rekt_key=rekt_key))
-   row = c.fetchone()
-   if row:
-      logger.info("checking record %s " % rekt_key)
-      rc = True 
-      if qty < row[2]:
-        logger.info("Rekkord %s has decreased open fill qty from %s to %s " % (rekt_key,row[2],qty))
-        try:
-          with conn:
-            c.execute("UPDATE Rekkage SET rekt_qty = %s WHERE rekt_key = '%s' " % (qty,rekt_key))
-          logger.info("Rekkord %s has been updated from %s to %s " % (rekt_key,row[2], qty))
-          msg = "Liquidation %s order for %s reduced size from %s to %s" % (side,symbol,row[2],qty)
-          WriteRekage([ msg ])
-        except BaseException as ex:
-          logger.error(format_exc())
-   else:
-      logger.info("Rek %s does NOT exist" % rekt_key)
-      try:
-        with conn:
-          c.execute("INSERT INTO {tn} (rekt_key,rekt_symbol,rekt_qty,rekt_price,rekt_position,rekt_side,rekt_ts) VALUES ('{rekt_key}','{rekt_symbol}',{rekt_qty},{rekt_price},'{rekt_position}','{rekt_side}',(CURRENT_TIMESTAMP))".format(tn=table_name,rekt_key=rekt_key,rekt_symbol=symbol,rekt_qty=qty,rekt_price=price,rekt_position=position,rekt_side=side))
-          cur = conn.cursor()
-          cur.execute("SELECT * FROM {tn} WHERE {idf}='{rekt_key}'".format(tn=table_name, idf='rekt_key', rekt_key=rekt_key))
-          for row in cur:
-            logger.info("Rekkord '%s' has been Added " % row[0])
-      except BaseException as ex:
-        logger.error(format_exc())
+"""Insert or update a liquidation record."""
+def gotRek(rekt_key, symbol, qty, price, position, side, db_path="rekt.sqlite"):
+    rc = False
+    msg = []
+    table_name = 'rekkage'
+    with sqlite3.connect(db_path) as conn:
+        c = conn.cursor()
+        c.execute(
+            "SELECT * FROM {tn} WHERE {idf}='{rekt_key}'".format(
+                tn=table_name, idf='rekt_key', rekt_key=rekt_key
+            )
+        )
+        row = c.fetchone()
+        if row:
+            logger.info("checking record %s " % rekt_key)
+            rc = True
+            if qty < row[2]:
+                logger.info(
+                    "Rekkord %s has decreased open fill qty from %s to %s "
+                    % (rekt_key, row[2], qty)
+                )
+                try:
+                    with conn:
+                        c.execute(
+                            "UPDATE Rekkage SET rekt_qty = %s WHERE rekt_key = '%s' "
+                            % (qty, rekt_key)
+                        )
+                    logger.info(
+                        "Rekkord %s has been updated from %s to %s "
+                        % (rekt_key, row[2], qty)
+                    )
+                    msg = (
+                        "Liquidation %s order for %s reduced size from %s to %s"
+                        % (side, symbol, row[2], qty)
+                    )
+                    WriteRekage([msg])
+                except BaseException:
+                    logger.error(format_exc())
+        else:
+            logger.info("Rek %s does NOT exist" % rekt_key)
+            try:
+                with conn:
+                    c.execute(
+                        "INSERT INTO {tn} (rekt_key,rekt_symbol,rekt_qty,rekt_price,rekt_position,rekt_side,rekt_ts) VALUES ('{rekt_key}','{rekt_symbol}',{rekt_qty},{rekt_price},'{rekt_position}','{rekt_side}',(CURRENT_TIMESTAMP))".format(
+                            tn=table_name,
+                            rekt_key=rekt_key,
+                            rekt_symbol=symbol,
+                            rekt_qty=qty,
+                            rekt_price=price,
+                            rekt_position=position,
+                            rekt_side=side,
+                        )
+                    )
+                    cur = conn.cursor()
+                    cur.execute(
+                        "SELECT * FROM {tn} WHERE {idf}='{rekt_key}'".format(
+                            tn=table_name, idf='rekt_key', rekt_key=rekt_key
+                        )
+                    )
+                    for row in cur:
+                        logger.info("Rekkord '%s' has been Added " % row[0])
+            except BaseException:
+                logger.error(format_exc())
 
-   conn.close()
-   return rc
+    return rc
 
-''' Get rekt details '''
-def getRekage():
+"""Fetch liquidation information from BitMEX."""
+def getRekage(db_path="rekt.sqlite"):
 
    msgs = []
-   url = "https://www.bitmex.com/api/v1/order/liquidations"
+   url = base_url + "order/liquidations"
    
    try:
      r = requests.get(url)
@@ -163,18 +136,18 @@ def getRekage():
   
    data = json.loads(r.text)
    if data:
-      print(data)
+      logger.info(data)
       for rek in data:
           if rek["side"] == "Buy":
              position = "Short"
           else:
              position = "Long"
-          rc = gotRek(rek["orderID"], rek["symbol"],rek["leavesQty"],rek["price"],position,rek["side"])
+          rc = gotRek(rek["orderID"], rek["symbol"], rek["leavesQty"], rek["price"], position, rek["side"], db_path=db_path)
           if not rc and float(rek["leavesQty"]) > 0:
              msgs.append("Liquidated %s position on %s. Limit %s order for %s @ %s created on www.bitmex.com" % (position,rek["symbol"],rek["side"],rek["leavesQty"],rek["price"]))
    return msgs
 
-''' Write Rekage details to Twitter using details from getRekage '''
+"""Send liquidation messages to Twitter."""
 def WriteRekage(msgs):
 
    if msgs is None or len(msgs) == 0: 
@@ -200,9 +173,10 @@ def WriteRekage(msgs):
 if __name__ == "__main__":
 
    logger = SetupLogging()
+   RunOnce()
    logger.info('Starting RektBitmex ...')
-   addRekt()
-   addPID()
+   init_rekkage_db()
+   init_pid_db()
    SLEEPTIME = 5 # seconds
 
    run = None    

--- a/tests/test_rektrunner.py
+++ b/tests/test_rektrunner.py
@@ -1,0 +1,62 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from rektrunner import gotRek, getRekage, requests
+from database import init_rekkage_db, init_pid_db
+
+
+def test_init_tables(tmp_path):
+    db_file = tmp_path / "test.sqlite"
+    init_rekkage_db(db_path=str(db_file))
+    init_pid_db(db_path=str(db_file))
+    with sqlite3.connect(db_file) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        tables = {row[0] for row in cur.fetchall()}
+    assert "rekkage" in tables
+    assert "rekt_PID" in tables
+
+
+def test_gotRek_insert_update(tmp_path):
+    db_file = tmp_path / "test.sqlite"
+    init_rekkage_db(db_path=str(db_file))
+
+    # Insert new record
+    inserted = gotRek("key1", "XBTUSD", 100, 5000.0, "Long", "Buy", db_path=str(db_file))
+    assert inserted is False  # new record
+    with sqlite3.connect(db_file) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT rekt_qty FROM rekkage WHERE rekt_key='key1'")
+        qty = cur.fetchone()[0]
+    assert qty == 100
+
+    # Update existing with reduced quantity
+    updated = gotRek("key1", "XBTUSD", 50, 5000.0, "Long", "Buy", db_path=str(db_file))
+    assert updated is True
+    with sqlite3.connect(db_file) as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT rekt_qty FROM rekkage WHERE rekt_key='key1'")
+        qty = cur.fetchone()[0]
+    assert qty == 50
+
+
+def test_getRekage_success(monkeypatch, tmp_path):
+    db_file = tmp_path / "test.sqlite"
+    init_rekkage_db(db_path=str(db_file))
+
+    class FakeResponse:
+        status_code = 200
+        text = '[{"orderID":"1","symbol":"XBTUSD","leavesQty":10,"price":1000,"side":"Buy"}]'
+
+    def fake_get(url):
+        return FakeResponse()
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    msgs = getRekage(db_path=str(db_file))
+    assert msgs == [
+        "Liquidated Short position on XBTUSD. Limit Buy order for 10 @ 1000 created on www.bitmex.com"
+    ]


### PR DESCRIPTION
## Summary
- centralize table creation helpers in `database.py`
- fix SQL table creation bug and replace prints with logging
- use `base_url` from config in `rektrunner`
- add docstrings and optional DB path parameters
- enforce single instance and set up global logger
- update README with testing instructions and schema info
- add unit tests for DB helpers and liquidation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841061429d48328bd145b2d41a16147