### PR TITLE
Remove unused global statement

### DIFF
--- a/rektrunner.py
+++ b/rektrunner.py
@@ -19,7 +19,6 @@ logger = logging.getLogger('RektBitmex')
 """Setup logging with file and console output."""
 def SetupLogging():
    """Return configured logger."""
-   global logger
    # configure logger with file and console handlers
    logger.setLevel(logging.INFO)
 


### PR DESCRIPTION
## Summary
- clean up `SetupLogging` in `rektrunner.py`

## Testing
- `pytest -q`
- `flake8 .` *(fails: add_sql_rekt.py:1:1: F401 'os' imported but unused)*

------
https://chatgpt.com/codex/tasks/task_e_68410d8e3f1483288b69c42d8e47bdf7