### PR TITLE
Apply security and style improvements

### DIFF
--- a/tests/test_rektrunner.py
+++ b/tests/test_rektrunner.py
@@ -71,7 +71,7 @@ def test_getRekage_success(monkeypatch, tmp_path):
             '"side":"Buy"}]'
         )
 
-    def fake_get(url):
+    def fake_get(url, **kwargs):
         return FakeResponse()
 
     monkeypatch.setattr(requests, "get", fake_get)


### PR DESCRIPTION
## Summary
- refactor RunOnce to use PID file instead of shell call
- parameterize SQL queries and tidy whitespace
- add timeout to HTTP requests
- verify Twitter credentials before posting
- update test helper to accept request timeout

## Testing
- `flake8`
- `pytest -q`
- `coverage run -m pytest -q && coverage report -m`
- `bandit -r . -q`


------
https://chatgpt.com/codex/tasks/task_e_68411460e9788328a780012af3109d3d