### PR TITLE
Add coverage reporting

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,26 +14,26 @@ permissions:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.10"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
-      run: |
-        pytest
+        - uses: actions/checkout@v4
+        - name: Set up Python 3.10
+          uses: actions/setup-python@v3
+          with:
+            python-version: "3.10"
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install flake8 pytest pytest-cov
+            if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        - name: Lint with flake8
+          run: |
+            # stop the build if there are Python syntax errors or undefined names
+            flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+            # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+            flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        - name: Test with pytest
+          run: |
+            pytest --cov=. --cov-report=xml
+        - name: Upload coverage to Codecov
+          uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Bandit Security Check](https://github.com/laisee/rektbitmex/actions/workflows/main.yml/badge.svg)](https://github.com/laisee/rektbitmex/actions/workflows/main.yml)
 [![Python Version](https://img.shields.io/badge/python-3.8%2B-blue.svg)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Coverage Status](https://codecov.io/gh/laisee/rektbitmex/branch/master/graph/badge.svg)](https://codecov.io/gh/laisee/rektbitmex)
 
 # 💥 Rekt @ BitMEX Bot
 
@@ -76,11 +77,11 @@ credentials are read from environment variables as noted above.
 ## Test Coverage
 
 Unit tests are located in the `tests` directory and can be executed with
-`pytest`:
+`pytest` and the `pytest-cov` plugin:
 
 ```bash
-pytest -q
+pytest --cov=./
 ```
 
 There are four tests covering database initialisation, record insertion and the
-basic helper functions.
+basic helper functions. Coverage results are uploaded to [Codecov](https://codecov.io/gh/laisee/rektbitmex) and displayed in the badge above.


### PR DESCRIPTION
## Summary
- add pytest-cov and Codecov upload in the workflow
- show Codecov badge in README
- document how to run coverage locally
- fix indentation error in GitHub Actions YAML

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68427faabbac8328b73b3763cda502f1